### PR TITLE
update pyproject.toml for linux compatibility (#61)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "chardet",
     "pyserial",
     "psutil",
-    "wmi",
+    "wmi; sys_platform == 'win32'",  # only install on Windows
 ]
 
 [project.scripts]


### PR DESCRIPTION
This fixes the poetry install error on linux by making wmi install optionally only for Windows, but could be good to check if the windows installation still works as intended.