### PR TITLE
add docstring to file_convert.py -  closes #41 

### DIFF
--- a/shellman/commands/file_convert.py
+++ b/shellman/commands/file_convert.py
@@ -27,6 +27,42 @@ import yaml
 @click.option("--interactive","-i", is_flag=True, help="Pipe output to less (if no --output)")
 @click.option("--lang-help","-lh", "lang", help="Show localized help (pl, eng) instead of executing")
 def cli(file, from_format, to_format, output_file, pretty, interactive, lang):
+    """
+    Command-line interface for converting between JSON, YAML, and TOML formats.
+
+    Reads a configuration file in one format and converts it to another format.
+    Supports pretty-printing, interactive viewing with pager, and saving to files.
+    Args:
+        file (str | None): Path to the input file to convert.
+        from_format (str | None): Source format ("json", "yaml", or "toml").
+            Required unless `lang` is provided.
+        to_format (str | None): Target format ("json", "yaml", or "toml").
+            Required unless `lang` is provided.
+        output_file (str | None): Path to save converted output. If not provided,
+            prints to stdout or uses pager if `interactive` is True.
+        pretty (bool): Enable pretty-printing with indentation and formatting.
+            Affects JSON and YAML output.
+        interactive (bool): Use pager (less) to display output. If `output_file`
+            is specified, opens the saved file in pager after writing.
+        lang (str | None): Print localized help ("pl", "eng") instead of executing
+            the conversion.
+
+    Raises:
+        click.UsageError: If required arguments `file`, `from_format`, or 
+            `to_format` are missing (unless using `--lang-help`).
+        click.ClickException: If an unsupported format is specified or if
+            file parsing fails.
+
+    Examples:
+        Convert JSON to YAML with pretty formatting:
+            $ shellman file_convert config.json --from json --to yaml --pretty
+
+        Convert TOML to JSON and save to file:
+            $ shellman file_convert settings.toml --from toml --to json -o config.json
+
+        View conversion interactively:
+            $ shellman file_convert data.yaml --from yaml --to json --interactive
+    """
     # ---------- lokalizowana pomoc ---------- #
     if lang:
         _print_help_md(lang)
@@ -79,6 +115,7 @@ def cli(file, from_format, to_format, output_file, pretty, interactive, lang):
 
 # ---------- Markdown help loader ---------- #
 def _print_help_md(lang: str = "eng"):
+    """Print localized help text for the `file_convert` command."""
     lang_file = f"help_{lang.lower()}.md"
     try:
         help_path = importlib.resources.files("shellman").joinpath(


### PR DESCRIPTION
Docstring intended to be similar in style with the previous docstrings of other files